### PR TITLE
fix erase/remove operation on deAssignedPieces

### DIFF
--- a/include/protocol_session/detail/Buying.cpp
+++ b/include/protocol_session/detail/Buying.cpp
@@ -383,7 +383,7 @@ namespace detail {
         piece.downloaded();
 
         // Remove from unassigned queue if present
-        _deAssignedPieces.erase(std::remove(_deAssignedPieces.begin(), _deAssignedPieces.end(), index));
+        _deAssignedPieces.erase(std::remove(_deAssignedPieces.begin(), _deAssignedPieces.end(), index), _deAssignedPieces.end());
     }
 
     template <class ConnectionIdType>


### PR DESCRIPTION
The erase/remove combination call seems to fail and cause a segfault when the the deAssignedPieces queue is empty.

Examples on use of [std::erase/std::remove idiom](https://en.wikipedia.org/wiki/Erase%E2%80%93remove_idiom) suggest to erase a range, not just the returned iterator from the remove operation.

Doing this has resolved the issue