### PR TITLE
Can restart paid downloading when all sellers are gone

### DIFF
--- a/sources/include/protocol_session/Callbacks.hpp
+++ b/sources/include/protocol_session/Callbacks.hpp
@@ -125,8 +125,9 @@ using ReceivedValidPayment = std::function<void(const ConnectionIdType &,
                                                 uint64_t totalNumberOfPayments,
                                                 uint64_t totalAmountPaid)>;
 
+typedef std::function<void(void)> AllSellersGone;
+
 }
 }
 
 #endif // JOYSTREAM_PROTOCOLSESSION_CALLBACKS_HPP
-

--- a/sources/include/protocol_session/Session.cpp
+++ b/sources/include/protocol_session/Session.cpp
@@ -165,7 +165,8 @@ namespace protocol_session {
                                               const FullPieceArrived<ConnectionIdType> & fullPieceArrived,
                                               const SentPayment<ConnectionIdType> & sentPayment,
                                               const protocol_wire::BuyerTerms & terms,
-                                              const TorrentPieceInformation & information) {
+                                              const TorrentPieceInformation & information,
+                                              const AllSellersGone & allSellersGone) {
 
         // Prepare for exiting current state
         switch(_mode) {
@@ -208,7 +209,8 @@ namespace protocol_session {
                                                        fullPieceArrived,
                                                        sentPayment,
                                                        terms,
-                                                       information);
+                                                       information,
+                                                       allSellersGone);
     }
 
     template <class ConnectionIdType>

--- a/sources/include/protocol_session/Session.hpp
+++ b/sources/include/protocol_session/Session.hpp
@@ -86,7 +86,8 @@ namespace detail {
                        const FullPieceArrived<ConnectionIdType> &,
                        const SentPayment<ConnectionIdType> &,
                        const protocol_wire::BuyerTerms &,
-                       const TorrentPieceInformation &);
+                       const TorrentPieceInformation &,
+                       const AllSellersGone &);
 
         /**
          * Warning: Do not call any of these operations

--- a/sources/include/protocol_session/detail/Buying.cpp
+++ b/sources/include/protocol_session/detail/Buying.cpp
@@ -27,7 +27,8 @@ namespace detail {
                                      const FullPieceArrived<ConnectionIdType> & fullPieceArrived,
                                      const SentPayment<ConnectionIdType> & sentPayment,
                                      const protocol_wire::BuyerTerms & terms,
-                                     const TorrentPieceInformation & information)
+                                     const TorrentPieceInformation & information,
+                                     const AllSellersGone & allSellersGone)
         : _session(session)
         , _removedConnection(removedConnection)
         , _fullPieceArrived(fullPieceArrived)
@@ -35,7 +36,8 @@ namespace detail {
         , _state(BuyingState::sending_invitations)
         , _terms(terms)
         , _numberOfMissingPieces(0)
-        , _assignmentLowerBound(0) {
+        , _assignmentLowerBound(0)
+        , _allSellersGone(allSellersGone) {
         //, _lastStartOfSendingInvitations(0) {
 
         // Setup pieces
@@ -324,6 +326,8 @@ namespace detail {
         if(_session->_state == SessionState::started) {
 
             // Allocate pieces if we are downloading
+            // Timeout sellers if they have not seviced a piece in time.
+            // Reset state to allow restarting downloading after all sellers are gone
             if(_state == BuyingState::downloading) {
 
                 for(auto mapping : _sellers) {
@@ -353,7 +357,11 @@ namespace detail {
                         if(s.servicingPieceHasTimedOut(std::chrono::seconds(20))) // <== hard coded for now, logic will be factored out later! see PR on this
                             removeConnection(id, DisconnectCause::seller_servicing_piece_has_timed_out);
                     }
+
                 }
+
+                // If all sellers are gone, reset state
+                resetIfAllSellersGone();
             }
         }
     }
@@ -410,22 +418,7 @@ namespace detail {
             // ditch any existing sellers
             _sellers.clear();
 
-            for(auto mapping : _session->_connections) {
-
-                detail::Connection<ConnectionIdType> * c = mapping.second;
-
-                // Check that this peer is seller,
-                protocol_statemachine::AnnouncedModeAndTerms a = c->announcedModeAndTermsFromPeer();
-
-                // and has good enough terms to warrant an invitation,
-                // then send invitation
-                if(a.modeAnnounced() == protocol_statemachine::ModeAnnounced::sell && _terms.satisfiedBy(a.sellModeTerms())) {
-
-                    c->processEvent(protocol_statemachine::event::InviteSeller());
-
-                    std::cout << "Invited: " << IdToString(mapping.first) << std::endl;
-                }
-            }
+            sendInvitations();
         }
     }
 
@@ -561,6 +554,30 @@ namespace detail {
     }
 
     template <class ConnectionIdType>
+    void Buying<ConnectionIdType>::sendInvitations() const {
+
+      assert(_session->_state == SessionState::started);
+      assert(_state == BuyingState::sending_invitations);
+
+      for(auto mapping : _session->_connections) {
+
+          detail::Connection<ConnectionIdType> * c = mapping.second;
+
+          // Check that this peer is seller,
+          protocol_statemachine::AnnouncedModeAndTerms a = c->announcedModeAndTermsFromPeer();
+
+          // and has good enough terms to warrant an invitation,
+          // then send invitation
+          if(a.modeAnnounced() == protocol_statemachine::ModeAnnounced::sell && _terms.satisfiedBy(a.sellModeTerms())) {
+
+              c->processEvent(protocol_statemachine::event::InviteSeller());
+
+              std::cout << "Invited: " << IdToString(mapping.first) << std::endl;
+          }
+      }
+    }
+
+    template <class ConnectionIdType>
     bool Buying<ConnectionIdType>::tryToAssignAndRequestPiece(detail::Seller<ConnectionIdType> & s) {
 
         assert(_session->_state == SessionState::started);
@@ -659,8 +676,37 @@ namespace detail {
             }
         }
 
-        // Mark as seller as gone
+        // Mark as seller as gone, but is not removed from _sellers map
         s.removed();
+    }
+
+    template <class ConnectionIdType>
+    void Buying<ConnectionIdType>::resetIfAllSellersGone () {
+
+        assert(_state == BuyingState::downloading);
+        assert(_session->_state == SessionState::started);
+
+        // Find any seller that is not in gone state
+        auto seller = find_if(_sellers.begin(), _sellers.end(), [] ( std::pair<ConnectionIdType, detail::Seller<ConnectionIdType>> mapping) {
+          return mapping.second.state() != SellerState::gone;
+        });
+
+        // At least one seller is still connected
+        if(seller != _sellers.cend()) return;
+
+        std::cout << "All Sellers Are Gone" << std::endl;
+
+        // Notify client
+        _allSellersGone();
+
+        // Transition to sending invitations state
+        _state = BuyingState::sending_invitations;
+
+        // Clear sellers
+        _sellers.clear();
+
+        // Send invitations to all connections
+        sendInvitations();
     }
 
     template <class ConnectionIdType>

--- a/sources/include/protocol_session/detail/Buying.hpp
+++ b/sources/include/protocol_session/detail/Buying.hpp
@@ -47,7 +47,8 @@ public:
            const FullPieceArrived<ConnectionIdType> &,
            const SentPayment<ConnectionIdType> &,
            const protocol_wire::BuyerTerms &,
-           const TorrentPieceInformation &);
+           const TorrentPieceInformation &,
+           const AllSellersGone &);
 
     //// Connection level client events
 
@@ -116,6 +117,10 @@ public:
 
 private:
 
+    void sendInvitations () const;
+
+    void resetIfAllSellersGone ();
+
     //// Assigning pieces
 
     // Tries to assign an unassigned piece to given seller
@@ -145,6 +150,7 @@ private:
     RemovedConnectionCallbackHandler<ConnectionIdType> _removedConnection;
     FullPieceArrived<ConnectionIdType> _fullPieceArrived;
     SentPayment<ConnectionIdType> _sentPayment;
+    AllSellersGone _allSellersGone;
 
     // State
     BuyingState _state;

--- a/sources/test/SessionSpy.cpp
+++ b/sources/test/SessionSpy.cpp
@@ -43,7 +43,8 @@ void SessionSpy<ConnectionIdType>::toMonitoredBuyMode(const protocol_wire::Buyer
                         fullPieceArrivedCallbackSlot.hook(),
                         SentPayment<ConnectionIdType>([](const ConnectionIdType &, uint64_t, uint64_t, uint64_t, int) -> void {}), // not bothering to add monitoring to this now, session will be deprecated
                         terms,
-                        information);
+                        information,
+                        AllSellersGone([]() -> void {}));
 }
 
 template <class ConnectionIdType>


### PR DESCRIPTION
Solves Part of https://github.com/JoyStream/protocol_session-cpp/issues/5

Detect running out of sellers when downloading (in tick callback) and reset buying state to be able to start paid download again.

Add a protocol callback AllSellersGone to notify client when this event occurs.